### PR TITLE
Toolchain for kernel build

### DIFF
--- a/README
+++ b/README
@@ -1,6 +1,7 @@
 Read it first : https://github.com/peyo-hd/local_manifests
 
 # Build Kernel
+ Install gcc-arm-linux-gnueabihf
  $ cd kernel/rpi
  $ ARCH=arm scripts/kconfig/merge_config.sh arch/arm/configs/bcm2709_defconfig android/configs/android-base.cfg android/configs/android-recommended.cfg
  $ ARCH=arm CROSS_COMPILE=arm-linux-gnueabihf- make zImage


### PR DESCRIPTION
We could use cross-compilers installed via apt get package on Ubuntu host.
